### PR TITLE
Use the canonical Contact heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Ultralytics provides two licensing options to accommodate diverse use cases:
 - **AGPL-3.0 License:** This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license is ideal for students, researchers, and enthusiasts who wish to share their work and contribute back to the community. It promotes open collaboration and knowledge sharing. See the [LICENSE](https://github.com/ultralytics/iSky/blob/main/LICENSE) file for detailed terms.
 - **Enterprise License:** Tailored for commercial applications, this license allows for the integration of Ultralytics software and AI models into commercial products and services without the open-source requirements of AGPL-3.0. If your scenario involves commercial use, please contact us through [Ultralytics Licensing](https://www.ultralytics.com/license).
 
-## 🤝 Contact
+## 📮 Contact
 
 For bug reports and feature requests related to the Ultralytics iSky iOS App, please use [GitHub Issues](https://github.com/ultralytics/iSky/issues). For general questions, discussions, and support, join our vibrant community on [Discord](https://discord.com/invite/ultralytics)!
 


### PR DESCRIPTION
Align the README tail with the canonical Ultralytics structure: the Contact section used `## 🤝 Contact` instead of `## 📮 Contact`. Section content is unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updated the README contact section heading to use a mail-related emoji for clearer visual identification. 📮

### 📊 Key Changes

- Renamed the README heading from `🤝 Contact` to `📮 Contact`.
- No code, functionality, licensing, or app behavior changes were introduced.

### 🎯 Purpose & Impact

- Makes the contact section’s purpose more immediately recognizable. ✉️
- Improves README visual clarity with no impact on users or application functionality.